### PR TITLE
Ariasanovsky/issue11

### DIFF
--- a/az-discrete-opt/src/ir_tree/ir_min_tree.rs
+++ b/az-discrete-opt/src/ir_tree/ir_min_tree.rs
@@ -1,4 +1,3 @@
-use core::time;
 use std::collections::BTreeMap;
 
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord)]
@@ -25,6 +24,7 @@ impl ActionsTaken {
     }
 }
 
+// todo! move the root & root_cost outside the tree to batch-sized arrays
 pub struct IRMinTree<S> {
     root: S,
     root_cost: f32,
@@ -37,15 +37,55 @@ pub struct IRStateData {
     actions: Vec<IRActionData>,
 }
 
+/* todo! make family of trees:
+    * IQMinTree
+      * (I)nitial cost is calculated when rooting a tree
+      * (Q)quickly calculate rewards when new states are encountered
+      * thus, we use q(s, a) = r(s, a) + q'(s, a)
+    * IAMinTree
+      * (I)mmediately cost calculated when rooting a tree
+      * (A)ction rewards are calculated during the transition between states only
+      * we still use q(s, a) = r(s, a) + q'(s, a)
+        * but we initialize r(s, a) = 0 when s is added
+        * and we update r(s, a) when visiting (s, a) for the first time
+        * NOTE: this motivates replacing frequency with Option<NonzeroUsize>
+    * INTMinTree (similar to IAMinTree)
+      * (I)nitial cost is calculated when rooting a tree
+      * (N)ew states added also get their costs calculated and stored
+      * (T)erminal states also get their costs calculated and stored
+        * we still use q(s, a) = r(s, a) + q'(s, a)
+          * but we initialize r(s, a) = 0 when s is added
+          * and we update r(s, a) when visiting (s, a) for the first time
+          * NOTE: this motivates replacing frequency with Option<NonzeroUsize>
+    * TMinTree
+        * (T)erminal states get their costs calculated and stored
+          * only terminal states 
+*/
+
+/* todo! what to do when (s, a) transitions to a terminal state?
+  * in future visits to s, we need not consider a
+  * thus we can remove a from the action space
+  * if s has no actions, it is `fully explored`
+  * some refactors to consider:
+    * best_action returns an enum:
+      * action (and reward),
+      * fully_explored (with final gain)
+      * NOTE: enum with variants Vec<T> (T not ZST?) & f32 has size 3 * 8
+*/
+
+// todo! refactor into a pair of values
 pub struct IRActionData {
+    // not mut
     action: usize,
-    frequency: usize,
     probability: f32,
     reward: f32,
-    future_reward_sum: f32,
+    // mut
+    frequency: usize,
+    q_minus_r_sum: f32,
     upper_estimate: f32,
 }
 
+// todo! refactor without the globals, haven't thought too hard about it, low priority
 const C_PUCT: f32 = 5.0;
 const C_PUCT_0: f32 = 5.0;
 
@@ -60,7 +100,7 @@ impl IRActionData {
             frequency: 0,
             probability,
             reward,
-            future_reward_sum: 0.0,
+            q_minus_r_sum: 0.0,
             upper_estimate: u,
         }
     }
@@ -71,7 +111,7 @@ impl IRActionData {
             frequency,
             probability: _,
             reward: _,
-            future_reward_sum,
+            q_minus_r_sum: future_reward_sum,
             upper_estimate: _,
         } = self;
         *frequency += 1;
@@ -84,7 +124,7 @@ impl IRActionData {
             frequency: action_frequency,
             probability,
             reward,
-            future_reward_sum,
+            q_minus_r_sum: future_reward_sum,
             upper_estimate,
         } = self;
         let q = *reward + *future_reward_sum / frequency as f32;
@@ -147,7 +187,7 @@ impl<S> IRMinTree<S> {
                     frequency: 0,
                     probability: p,
                     reward: r,
-                    future_reward_sum: 0.0,
+                    q_minus_r_sum: 0.0,
                     upper_estimate: u,
                 }
             })
@@ -165,6 +205,7 @@ impl<S> IRMinTree<S> {
         }
     }
 
+    // refactor so that transitions instead hold &mut's to the values
     pub fn simulate_once(&self) -> (Transitions, S)
     where
         S: Clone + IRState,
@@ -212,6 +253,7 @@ impl<S> IRMinTree<S> {
         )
     }
 
+    // refactor without the `&mut self` to update the &mut values in-place
     pub fn update(&mut self, transitions: &Transitions, gains: &[f32]) {
         let Self {
             root_cost: _,
@@ -254,6 +296,7 @@ impl<S> IRMinTree<S> {
         root_data.update_future_reward(*first_action, approximate_gain_to_terminal);
     }
 
+    // todo! this only uses the end path
     pub fn insert(
         &mut self,
         transitions: &Transitions,
@@ -280,6 +323,7 @@ impl<S> IRMinTree<S> {
         }
     }
 
+    // todo! this is only a method on `root_data`
     pub fn observations(&self) -> Vec<f32>
     where
         S: IRState,
@@ -299,7 +343,7 @@ impl<S> IRMinTree<S> {
                 frequency: action_frequency,
                 probability: _,
                 reward,
-                future_reward_sum,
+                q_minus_r_sum: future_reward_sum,
                 upper_estimate: _,
             } = a;
             gain_sum += *reward;
@@ -344,6 +388,7 @@ impl SearchEnd {
     }
 }
 
+// todo! refactor with &mut's to the tree's values instead of vecs of cloned vecs
 pub struct Transitions {
     first_action: usize,
     first_reward: f32,

--- a/az-discrete-opt/src/ir_tree/ir_min_tree.rs
+++ b/az-discrete-opt/src/ir_tree/ir_min_tree.rs
@@ -334,6 +334,7 @@ impl<S> IRMinTree<S> {
                 q_minus_r_sum: future_reward_sum,
                 upper_estimate: _,
             } = a;
+            // todo! should there be a max(0.0) here?
             gain_sum += *reward;
             gain_sum += *future_reward_sum;
             *observations.get_mut(*action).unwrap() = *action_frequency as f32 / *frequency as f32;

--- a/ramsey/Cargo.toml
+++ b/ramsey/Cargo.toml
@@ -14,7 +14,12 @@ az-discrete-opt = { version = "0.1.0", path = "../az-discrete-opt" }
 itertools = "0.11.0"
 
 [dev-dependencies]
+criterion = "0.5.1"
 dfdx = { version = "0.13.0", default-features = false, features = ["std", "fast-alloc", "cuda", "cudnn"]}
 priority-queue = "1.3.2"
 rand = "0.8.5"
 rayon = "1.7.0"
+
+[[bench]]
+name = "r44_17_search_tree_with_trivial_predictions"
+harness = false

--- a/ramsey/benches/r44_17_search_tree_with_trivial_predictions.rs
+++ b/ramsey/benches/r44_17_search_tree_with_trivial_predictions.rs
@@ -13,7 +13,14 @@ fn r44_17_search_tree_with_trivial_predictions(c: &mut Criterion) {
         1_000_000_000,
     ] {
         group.bench_with_input(BenchmarkId::new("perform a search with a given length and ...?", n), &n, |b, &n| {
-            b.iter(|| todo!())
+            b.iter(|| {
+                // construct a root
+                // construct a search tree
+                // perform a search with a given length and ...?
+                // calculate the observations
+                // maybe loop the search -- root a new tree at a chosesn value from the search and repeat
+                black_box(todo!("put some output here"))
+            })
         });
     }
 }

--- a/ramsey/benches/r44_17_search_tree_with_trivial_predictions.rs
+++ b/ramsey/benches/r44_17_search_tree_with_trivial_predictions.rs
@@ -1,0 +1,22 @@
+#![allow(unused)]
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+fn r44_17_search_tree_with_trivial_predictions(c: &mut Criterion) {
+    let mut group = c.benchmark_group("r44_17_search_tree_with_trivial_predictions");
+    for n in [
+        10_000i32,
+        100_000,
+        1_000_000,
+        10_000_000,
+        100_000_000,
+        1_000_000_000,
+    ] {
+        group.bench_with_input(BenchmarkId::new("perform a search with a given length and ...?", n), &n, |b, &n| {
+            b.iter(|| todo!())
+        });
+    }
+}
+
+criterion_group!(benches, r44_17_search_tree_with_trivial_predictions);
+criterion_main!(benches);

--- a/ramsey/examples/04-r44.rs
+++ b/ramsey/examples/04-r44.rs
@@ -19,6 +19,7 @@ const ACTION: usize = C * E;
 
 type Tree = IRMinTree<GraphState>;
 
+// todo! move to ir_min_tree
 fn plant_forest(states: &[GraphState; BATCH], predictions: &[ActionVec; BATCH]) -> [Tree; BATCH] {
     let mut trees: [MaybeUninit<Tree>; BATCH] = unsafe {
         let trees: MaybeUninit<[Tree; BATCH]> = MaybeUninit::uninit();
@@ -70,6 +71,7 @@ impl GraphLogs {
     }
 }
 
+// todo? move to ir_min_tree
 fn par_update_logs(logs: &mut [GraphLogs; BATCH], transitions: &[Trans; BATCH]) {
     let logs = logs.par_iter_mut();
     let transitions = transitions.par_iter();
@@ -189,6 +191,7 @@ fn main() {
     });
 }
 
+// todo! move to ir_min_tree
 fn par_update_roots(roots: &mut [GraphState; BATCH], logs: &[GraphLogs; BATCH], time: usize) {
     let roots = roots.par_iter_mut();
     let logs = logs.par_iter();
@@ -198,6 +201,7 @@ fn par_update_roots(roots: &mut [GraphState; BATCH], logs: &[GraphLogs; BATCH], 
     });
 }
 
+// todo! move to ir_min_tree
 fn par_insert_into_forest(
     trees: &mut [Tree; BATCH],
     transitions: &[Trans; BATCH],
@@ -215,6 +219,7 @@ fn par_insert_into_forest(
         .for_each(|(((tree, trans), state), probs)| tree.insert(trans, state, probs));
 }
 
+// todo! move to ir_min_tree
 fn par_forest_observations(trees: &[Tree; BATCH]) -> ([ActionVec; BATCH], [ValueVec; BATCH]) {
     let mut probabilities: [ActionVec; BATCH] = [[0.0f32; ACTION]; BATCH];
     let mut values: [ValueVec; BATCH] = [[0.0f32; VALUE]; BATCH];
@@ -250,6 +255,7 @@ fn par_update_forest(
         });
 }
 
+// todo! move to ir_min_tree
 fn par_state_batch_to_vecs(states: &[GraphState; BATCH]) -> [StateVec; BATCH] {
     let mut state_vecs: [MaybeUninit<StateVec>; BATCH] = unsafe {
         let state_vecs: MaybeUninit<[StateVec; BATCH]> = MaybeUninit::uninit();
@@ -264,6 +270,7 @@ fn par_state_batch_to_vecs(states: &[GraphState; BATCH]) -> [StateVec; BATCH] {
     unsafe { transmute(state_vecs) }
 }
 
+// todo! move to ir_min_tree
 fn par_simulate_forest_once(trees: &[Tree; BATCH]) -> ([Trans; BATCH], [GraphState; BATCH]) {
     let mut transitions: [MaybeUninit<Trans>; BATCH] = unsafe {
         let transitions: MaybeUninit<[Trans; BATCH]> = MaybeUninit::uninit();

--- a/ramsey/src/ramsey_state.rs
+++ b/ramsey/src/ramsey_state.rs
@@ -13,6 +13,15 @@ use crate::{
     MulticoloredGraphNeighborhoods, OrderedEdgeRecolorings, C, E, N,
 };
 
+/* todo! remove globals
+  * macros (and traits) to handle:
+    * E-sized arrays (no const generics ;____;)
+    * optimal choices of bitsets
+  * generalize for clique size != 4
+  * generalize for imbalanced weights for different clique sizes
+    * renormalize w.r.t. the expected counts in the optimal G(n, \vec{p}) graph
+      * solve for optimum w/ lagrange multiplier
+*/
 pub const BATCH: usize = 64;
 const ACTION: usize = C * E;
 
@@ -293,6 +302,7 @@ impl IRState for GraphState {
             .collect()
     }
 
+    // todo! lol
     fn act(&mut self, action: usize) {
         let Self {
             colors: ColoredCompleteGraph(colors),


### PR DESCRIPTION
Actions now accumulate values of the form `max(0, g)` in a more aptly-named variable `q_minus_r_sum`. Our model more consistently predicts the maxum of 0 & max c(s)-c(s') taken over all s' seen on a search rooted at s.

Question: does the `fn observations` need a `max(0.0)`?